### PR TITLE
chore(ci): split vm bridge canary into pinned and floating lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           name: dist
           path: dist/*
 
-  vm-bridge-canary:
+  vm-bridge-canary-floating:
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -70,12 +70,58 @@ jobs:
         with:
           repository: t81dev/t81-vm
           path: t81-vm
+          ref: main
 
       - name: Checkout t81-lang
         uses: actions/checkout@v4
         with:
           repository: t81dev/t81-lang
           path: t81-lang
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build VM + emit canary
+        run: |
+          make -C t81-vm build-check
+          python3 t81-lang/scripts/emit-canary-bytecode.py t81-vm/build/canary.tisc.json
+
+      - name: Install package + run bridge canary
+        working-directory: t81-python
+        env:
+          T81_VM_LIB: ${{ github.workspace }}/t81-vm/build/libt81vm_capi.so
+          T81_VM_CANARY_PROGRAM: ${{ github.workspace }}/t81-vm/build/canary.tisc.json
+          PYTHONPATH: src
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+          pytest -q tests/test_vm_bridge.py
+
+  vm-bridge-canary-pinned:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout t81-python
+        uses: actions/checkout@v4
+        with:
+          path: t81-python
+
+      - name: Checkout t81-vm pinned contract
+        uses: actions/checkout@v4
+        with:
+          repository: t81dev/t81-vm
+          path: t81-vm
+          ref: runtime-contract-v0.1
+
+      - name: Checkout t81-lang
+        uses: actions/checkout@v4
+        with:
+          repository: t81dev/t81-lang
+          path: t81-lang
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,6 +33,9 @@ Public CLI commands are treated as stable contract surface once documented in `R
   - use `T81_VM_LIB` if set,
   - else attempt workspace-local `t81-vm/build/libt81vm_capi.{dylib,so}`.
 - ABI and bridge regressions are covered by `tests/test_vm_bridge.py`.
+- CI coverage:
+  - floating lane against latest `t81-vm/main`,
+  - pinned lane against `runtime-contract-v0.1`.
 
 ## Release Cadence Rule
 


### PR DESCRIPTION
Adds dual runtime integration lanes: floating against latest main and pinned against runtime-contract-v0.1.